### PR TITLE
FEATURE: New version: 1.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,33 @@
+---
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install uv
+        uv pip install . --system 
+        uv pip install -r requirements-dev.txt --system
+
+    - name: Execute unit tests
+      run: pytest --cov-fail-under=80

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
+![CI](https://github.com/adammotzel/pyglms/actions/workflows/ci.yaml/badge.svg)
 ![coverage](https://img.shields.io/badge/coverage-94%25-brightgreen)
+![Python](https://img.shields.io/badge/python-3.10%20--%203.13-blue)
+![License](https://img.shields.io/github/license/adammotzel/pyglms)
+
 
 
 # PyGLMs
 
 An implementation of various Generalized Linear Models (GLMs), written in Python.
 
-I created this package as a personal refresher on GLMs and the underlying optimization techniques. It's intended as a learning tool and a reference for building and understanding these models from the ground up.
+I created this package as a refresher on GLMs and the underlying optimization techniques. It's intended as a learning tool and a reference for building and understanding these models from the ground up.
 
 
 ## Overview
@@ -22,18 +26,9 @@ The following models have been implemented:
 
 The `GLM` parent class supports three optimization methods for parameter estimation: Momentum-based Gradient Descent for first-order optimization, Newton's Method for second-order optimization, and Limited-memory Broyden–Fletcher–Goldfarb–Shanno (L-BFGS). The user can specify the desired optimization `method` during class instantiation.
 
-Momentum-based Gradient Descent and Newton's Method are implemented in Python as part of the `turtles` distribution. L-BFGS is implemented using `scipy.optimize`, which is written in C. It's a quasi-Newton method that approximates the Hessian (instead of fully computing it, like Newton's Method), so it's quite fast.
+Momentum-based Gradient Descent and Newton's Method are implemented in Python as part of the `turtles` distribution. L-BFGS is implemented using `scipy.optimize`; it's a quasi-Newton method that approximates the Hessian (instead of fully computing it, like Newton's Method), so it's quite fast.
 
 See `examples/{class name}_example.ipynb` for simple examples of using each model class and various supporting functions.
-
-
-## Setup
-
-You can simply pip install the repo to start using the package:
-
-```bash
-pip install git+https://github.com/adammotzel/pyglms.git
-```
 
 
 ## Contributing
@@ -44,16 +39,16 @@ To run (and edit) this project locally, clone the repo and create your virtual e
 python -m venv venv
 ```
 
-Activate the env (`source venv/Scripts/activate` for Windows OS, `source venv/bin/activate` for Linux).
-
-Install dependencies:
+Activate the env (`source venv/Scripts/activate` for Windows OS, `source venv/bin/activate` for Linux) and install dependencies:
 
 ```bash
+pip install . 
 pip install -r requirements-dev.txt
 ```
-**NOTE**: `requirements-dev.txt` contains the dev dependencies, some of which are not part of the packaged distribution. It also includes the `turtles` package in editable mode. See the `pyproject.toml` file for true package dependencies.
 
-Optionally, you can execute `scripts/env.sh` to create and activate the virtual environment using `uv`. The `uv`package manager must be installed for this to work.
+**NOTE**: `requirements-dev.txt` contains the dev dependencies, which are not part of the packaged distribution. See the `pyproject.toml` file for true package dependencies.
+
+Optionally, you can execute `scripts/env.sh` to create and activate a virtual environment using `uv`. The `uv` package manager must be installed for this to work.
 
 
 ### Adding GLMs
@@ -63,19 +58,10 @@ To add more GLM classes, use the `GLM` parent class for inheritence (see `Poisso
 
 ## Testing
 
-All tests are contained within `tests` directories for each module. You can simply execute the `pytest` command to run all unit tests.
+All tests are contained within `tests` directories for each module. You can simply execute the `pytest` command from project root to run all unit tests.
 
 ```bash
-pytest turtles
-```
-
-
-### Test Coverage
-
-You can also generate a test coverage report.
-
-```bash
-pytest --cov=turtles --cov-report=term-missing --cov-config=.coveragerc -p no:warnings
+pytest
 ```
 
 **Notes on Test Coverage:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turtles"
-version = "0.1.1"
-requires-python = ">= 3.9"
+version = "1.0.0"
+requires-python = ">= 3.10"
 dependencies = [
     "numpy>=2.0.2",
     "pandas>=2.2.3",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
-addopts = -v
+addopts = -v --cov=turtles --cov-report=term-missing --cov-config=.coveragerc
+testpaths = turtles
+python_files = test_*.py
 filterwarnings =
     ignore::RuntimeWarning
     ignore::DeprecationWarning

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,3 @@ pytest-cov>=6.2.1
 scikit-learn>=1.6.1
 statsmodels>=0.14.4
 ipykernel>=6.29.5
--e .

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -10,6 +10,7 @@ else
     echo "Could not find the activation script for the virtual environment."
 fi
 
+uv pip install . 
 uv pip install -r requirements-dev.txt
 
 echo ""

--- a/turtles/__init__.py
+++ b/turtles/__init__.py
@@ -2,7 +2,7 @@
 Configure global settings for package.
 """
 
-__version__ = "0.1.1"
+__version__ = "1.0.0"
 
 # modules
 __all__ = [


### PR DESCRIPTION
Add some CI stuff:
- Add `ci.yaml` to execute unit tests when a PR is raised to merge into `main`
- Update test configurations

Bump major version. New version is `1.0.0`.

When executing unit tests locally, I noticed some unexpected behavior with `turtles.stats.pca`: the signs of some principal components were flipped, causing failures. This was only present in Python `3.9`. New `pyproject.toml` specifies `>-3.10`.