### PR TITLE
BUGFIX: Catch singular matrices when computing Hessian

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,19 +4,19 @@ repos:
     hooks:
       - id: black
         language_version: python3.12
-        files: ^src/
+        files: ^turtles/
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.13.2
     hooks:
       - id: isort
         language_version: python3.12
-        files: ^src/
+        files: ^turtles/
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.9
     hooks:
       - id: ruff
         args: ["--fix"]
-        files: ^src/
+        files: ^turtles/
         

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        language_version: python3.12
+        files: ^src/
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        language_version: python3.12
+        files: ^src/
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+        files: ^src/
+        

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ![CI](https://github.com/adammotzel/pyglms/actions/workflows/ci.yaml/badge.svg)
-![coverage](https://img.shields.io/badge/coverage-94%25-brightgreen)
+![coverage](https://img.shields.io/badge/coverage-93%25-brightgreen)
 ![Python](https://img.shields.io/badge/python-3.10%20--%203.13-blue)
 ![License](https://img.shields.io/github/license/adammotzel/pyglms)
  ![PyPI](https://img.shields.io/pypi/v/turtles-glms.svg)
 
 
-# PyGLMs (Turtles)
+# PyGLMs (Turtles) 🐢
 
 An implementation of various Generalized Linear Models (GLMs), written in Python.
 
@@ -28,8 +28,6 @@ The `GLM` parent class supports three optimization methods for parameter estimat
 
 Momentum-based Gradient Descent and Newton's Method are implemented in Python as part of the `turtles` distribution. L-BFGS is implemented using `scipy.optimize`; it's a quasi-Newton method that approximates the Hessian (instead of fully computing it, like Newton's Method), so it's quite fast.
 
-See `examples/{class name}_example.ipynb` for simple examples of using each model class and various supporting functions.
-
 
 ## Usage
 
@@ -38,6 +36,29 @@ You can pip install the package from PyPI:
 ```bash
 pip install turtles-glms
 ```
+
+See `examples/` in the [GitHub repo](https://github.com/adammotzel/pyglms) for example usage of the GLM classes and statistical functions.
+
+### Fitting GLMs
+
+You can fit GLMs by instantiating a GLM class and calling its `fit()` method.
+
+```python
+model = PoissonReg(
+    method="newton",
+    learning_rate=0.01
+)
+n_model.fit(
+    X=X, 
+    y=y, 
+    exposure=exposure
+)
+```
+
+A few important notes about fitting `turtles` GLMs:
+1. The `fit()` method parameters `X`, `y`, and (for Poisson) `exposure` must be `numpy` arrays. Parameters `y` and `exposure` must be of shape `(M, 1)`, where `M` is the number of rows in the data. The package does not support `pandas` or `polars` dataframes at this time. See class / instance method docstrings for exact requirements.
+2. Each GLM class has a `learning_rate` parameter, applicable to Gradient Descent and Newton's optimization methods. The learning rate (or step size) is a hyperparameter that controls the magnitude of parameter updates during the optimization process. If it's too large, the Hessian matrix may become singular, in which case the learning rate should be decreased. This is typically part of the tuning process.
+3. There are currently no regularization methods implemented in the package. Future versions may include L1, L2, and Elastic Net methods.
 
 
 ## Contributing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turtles-glms"
-version = "1.0.0"
+version = "1.0.1"
 requires-python = ">= 3.10"
 dependencies = [
     "numpy>=2.0.2",
@@ -31,7 +31,8 @@ dev = [
     "pytest-cov>=6.2.1",
     "scikit-learn>=1.6.1",
     "statsmodels>=0.14.4",
-    "ipykernel>=6.29.5"
+    "ipykernel>=6.29.5",
+    "pre-commit>=4.5.0",
 ]
 
 [tool.setuptools.packages.find]
@@ -41,3 +42,7 @@ exclude = ["tests", "*tests*", "examples", "scripts"]
 [project.urls]
 Homepage = "https://github.com/adammotzel/pyglms"
 Issues = "https://github.com/adammotzel/pyglms/issues"
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -5,6 +5,8 @@ uv venv --python 3.10
 source .venv/Scripts/activate || source .venv/bin/activate
 uv sync --all-extras
 
+pre-commit install
+
 echo ""
 echo "Virtual environment created and activated."
 echo ""

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+pytest --cov=turtles --cov-report=term-missing --cov-config=.coveragerc -p no:warnings

--- a/turtles/__init__.py
+++ b/turtles/__init__.py
@@ -2,7 +2,7 @@
 Configure global settings for package.
 """
 
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version("turtles-glms")
@@ -10,8 +10,4 @@ except PackageNotFoundError:
     __version__ = "0.0.0"
 
 # modules
-__all__ = [
-    "preprocess",
-    "stats",
-    "plotting"
-]
+__all__ = ["preprocess", "stats", "plotting"]

--- a/turtles/_utils.py
+++ b/turtles/_utils.py
@@ -2,12 +2,7 @@
 General utility functions.
 """
 
-from typing import (
-    Dict, 
-    Tuple, 
-    Any, 
-    Union
-)
+from typing import Any, Dict, Tuple, Union
 
 import numpy as np
 
@@ -34,21 +29,17 @@ def _shape_check(x: np.ndarray, var_name: str, dim: int = 1):
     """
 
     if np.ndim(x) == 1 or x.shape[1] < dim:
-        raise ValueError(
-            f"'{var_name}' must contain more than {dim} dimensions."
-        )
-    
+        raise ValueError(f"'{var_name}' must contain more than {dim} dimensions.")
 
-def _validate_args(
-    map: Dict[str, Tuple[Any, Union[type, Tuple[type, ...]]]]
-):
+
+def _validate_args(map: Dict[str, Tuple[Any, Union[type, Tuple[type, ...]]]]):
     """
     Simple type validation of a set of input arguments.
 
     Parameters
     ----------
     map : Dict[str, Tuple[Any, Union[type, Tuple[type, ...]]]]
-        A dictionary where keys are the argument names and the values are 
+        A dictionary where keys are the argument names and the values are
         tuples containing:
         - the object to check
         - the expected type or a tuple of types
@@ -62,7 +53,7 @@ def _validate_args(
     -------
     _validate_args(
         {
-            'X': (X, np.array), 
+            'X': (X, np.array),
             'Y': (Y, (int, float))
         }
     )
@@ -98,12 +89,8 @@ def _add_intercept(X: np.ndarray) -> np.ndarray:
         Design matrix with the intercept as the first column.
     """
 
-    _validate_args(
-        {
-            "X": (X, np.ndarray)
-        }
-    )
-    
+    _validate_args({"X": (X, np.ndarray)})
+
     m = X.shape[0]
     intercept = np.ones(m).reshape(m, 1)
     X = np.concatenate((intercept, X), axis=1)

--- a/turtles/plotting/__init__.py
+++ b/turtles/plotting/__init__.py
@@ -4,11 +4,6 @@ Plotting module.
 Contains various plotting functions.
 """
 
-from ._plotting import (
-    plot_y_vs_x
-)
+from ._plotting import plot_y_vs_x
 
-
-__all__ = [
-    "plot_y_vs_x"
-]
+__all__ = ["plot_y_vs_x"]

--- a/turtles/plotting/_plotting.py
+++ b/turtles/plotting/_plotting.py
@@ -2,18 +2,18 @@
 Plotting functions.
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
 from .._utils import _validate_args
 
 
 def plot_y_vs_x(
-        x: np.ndarray, 
-        y: np.ndarray, 
-        title: str = "Dependent vs. Independent",
-        xlabel: str = "Independent",
-        ylabel: str = "Dependent"
+    x: np.ndarray,
+    y: np.ndarray,
+    title: str = "Dependent vs. Independent",
+    xlabel: str = "Independent",
+    ylabel: str = "Dependent",
 ):
     """
     Scatter plot of a variable (y) against another variable (x).
@@ -45,16 +45,11 @@ def plot_y_vs_x(
             "y": (y, np.ndarray),
             "title": (title, str),
             "xlabel": (xlabel, str),
-            "ylabel": (ylabel, str)
+            "ylabel": (ylabel, str),
         }
     )
 
-    plt.scatter(
-        x=x,
-        y=y,
-        color="blue", 
-        edgecolor="black"
-    )
+    plt.scatter(x=x, y=y, color="blue", edgecolor="black")
     plt.title(title)
     plt.xlabel(xlabel)
     plt.ylabel(ylabel)

--- a/turtles/plotting/tests/test_plotting.py
+++ b/turtles/plotting/tests/test_plotting.py
@@ -28,6 +28,7 @@ def test_default_labels_and_title():
     y = np.array([2, 4, 6, 8])
 
     with (
+        patch("matplotlib.pyplot.show") as mock_show,
         patch("matplotlib.pyplot.title") as mock_title,
         patch("matplotlib.pyplot.xlabel") as mock_xlabel,
         patch("matplotlib.pyplot.ylabel") as mock_ylabel,
@@ -35,6 +36,7 @@ def test_default_labels_and_title():
 
         plot_y_vs_x(x, y)
 
+        mock_show.assert_called()
         mock_title.assert_called_with("Dependent vs. Independent")
         mock_xlabel.assert_called_with("Independent")
         mock_ylabel.assert_called_with("Dependent")
@@ -50,6 +52,7 @@ def test_custom_labels_and_title():
     ylabel = "Custom Y-Axis"
 
     with (
+        patch("matplotlib.pyplot.show") as mock_show,
         patch("matplotlib.pyplot.title") as mock_title,
         patch("matplotlib.pyplot.xlabel") as mock_xlabel,
         patch("matplotlib.pyplot.ylabel") as mock_ylabel,
@@ -57,6 +60,7 @@ def test_custom_labels_and_title():
 
         plot_y_vs_x(x, y, title=title, xlabel=xlabel, ylabel=ylabel)
 
+        mock_show.assert_called()
         mock_title.assert_called_with(title)
         mock_xlabel.assert_called_with(xlabel)
         mock_ylabel.assert_called_with(ylabel)

--- a/turtles/plotting/tests/test_plotting.py
+++ b/turtles/plotting/tests/test_plotting.py
@@ -6,9 +6,7 @@ from unittest.mock import patch
 
 import numpy as np
 
-from ...plotting import (
-    plot_y_vs_x
-)
+from ...plotting import plot_y_vs_x
 
 
 def test_plot_valid_inputs():
@@ -20,7 +18,7 @@ def test_plot_valid_inputs():
     # patch plt.show to avoid displaying the plot during testing
     with patch("matplotlib.pyplot.show") as mock_show:
         plot_y_vs_x(x, y)
-        mock_show.assert_called_once() 
+        mock_show.assert_called_once()
 
 
 def test_default_labels_and_title():
@@ -28,11 +26,12 @@ def test_default_labels_and_title():
 
     x = np.array([1, 2, 3, 4])
     y = np.array([2, 4, 6, 8])
-    
-    with patch("matplotlib.pyplot.show") as mock_show, \
-        patch("matplotlib.pyplot.title") as mock_title, \
-        patch("matplotlib.pyplot.xlabel") as mock_xlabel, \
-        patch("matplotlib.pyplot.ylabel") as mock_ylabel:
+
+    with (
+        patch("matplotlib.pyplot.title") as mock_title,
+        patch("matplotlib.pyplot.xlabel") as mock_xlabel,
+        patch("matplotlib.pyplot.ylabel") as mock_ylabel,
+    ):
 
         plot_y_vs_x(x, y)
 
@@ -50,10 +49,11 @@ def test_custom_labels_and_title():
     xlabel = "Custom X-Axis"
     ylabel = "Custom Y-Axis"
 
-    with patch("matplotlib.pyplot.show") as mock_show, \
-        patch("matplotlib.pyplot.title") as mock_title, \
-        patch("matplotlib.pyplot.xlabel") as mock_xlabel, \
-        patch("matplotlib.pyplot.ylabel") as mock_ylabel:
+    with (
+        patch("matplotlib.pyplot.title") as mock_title,
+        patch("matplotlib.pyplot.xlabel") as mock_xlabel,
+        patch("matplotlib.pyplot.ylabel") as mock_ylabel,
+    ):
 
         plot_y_vs_x(x, y, title=title, xlabel=xlabel, ylabel=ylabel)
 

--- a/turtles/preprocess/__init__.py
+++ b/turtles/preprocess/__init__.py
@@ -5,13 +5,7 @@ Functions support common data transformation tasks to prep datasets
 for GLMs.
 """
 
-from ._transform import (
-    one_hot_encode
-)
 from .._utils import _add_intercept as add_intercept
+from ._transform import one_hot_encode
 
-
-__all__ = [
-    "one_hot_encode",
-    "add_intercept"
-]
+__all__ = ["one_hot_encode", "add_intercept"]

--- a/turtles/preprocess/_transform.py
+++ b/turtles/preprocess/_transform.py
@@ -7,23 +7,21 @@ from typing import List, Tuple, Union
 import numpy as np
 import pandas as pd
 
-from .._utils import (
-    _validate_args,
-)
+from .._utils import _validate_args
 
 
 def one_hot_encode(
-    df: pd.DataFrame, 
+    df: pd.DataFrame,
     columns: List[str],
     drop_first: bool = True,
-    return_df: bool = True
+    return_df: bool = True,
 ) -> Union[pd.DataFrame, Tuple[np.ndarray, List[str]]]:
     """
     One Hot Encode categorical variables in a Pandas DataFrame, also known
     as dummy variables or indicator variables.
 
     This is essentially just a wrapper around the Pandas `get_dummies()`
-    function, but it optioanlly returns a Numpy matrix, making the resulting 
+    function, but it optioanlly returns a Numpy matrix, making the resulting
     object immediately compatible with the `turtles` GLM classes.
 
     https://pandas.pydata.org/docs/reference/api/pandas.get_dummies.html
@@ -33,49 +31,46 @@ def one_hot_encode(
     df : pd.DataFrame, shape (M, N)
         Pandas DataFrame containing data to be encoded.
     columns : List[str]
-        List of column names in `df` to be encoded. Column values must be 
+        List of column names in `df` to be encoded. Column values must be
         strings or categorical.
     drop_first : bool, default True
         Whether to drop the first category from the resulting table. Dropping
         the first category is useful when building a GLM, because the dropped
-        category will then be treated as the 'base case' or 'reference category' 
+        category will then be treated as the 'base case' or 'reference category'
         for model coefficient interpretation.
     return_df : bool, default True
-        Optionally return a pandas DataFrame. If False, a Tuple of a numpy 
+        Optionally return a pandas DataFrame. If False, a Tuple of a numpy
         matrix and resulting column names is returned.
 
     Returns
     -------
     Union[pd.DataFrame, Tuple[np.ndarray, List[str]]]
-    
-        If `return_df` = True, a pandas DataFrame is returned, containing the 
+
+        If `return_df` = True, a pandas DataFrame is returned, containing the
         encoded columns.
-        
-        If `return_df` = False, a Tuple is returned, where the new matrix is 
+
+        If `return_df` = False, a Tuple is returned, where the new matrix is
         in position [0] and the list of new column names in position [1].
     """
-    
+
     _validate_args(
         {
             "df": (df, pd.DataFrame),
             "columns": (columns, list),
             "drop_first": (drop_first, bool),
-            "return_df": (return_df, bool)
+            "return_df": (return_df, bool),
         }
     )
 
     temp = df.copy()
 
     one_hot_encoded_df = pd.get_dummies(
-        temp, 
-        columns=columns,
-        drop_first=drop_first,
-        dtype=int
+        temp, columns=columns, drop_first=drop_first, dtype=int
     )
 
     if return_df:
         return one_hot_encoded_df
-    
+
     column_names = list(one_hot_encoded_df.columns)
-    
+
     return one_hot_encoded_df.to_numpy(), column_names

--- a/turtles/preprocess/tests/test_transform.py
+++ b/turtles/preprocess/tests/test_transform.py
@@ -2,8 +2,8 @@
 Unit tests for functions from the preprocess module.
 """
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 
 from ...preprocess import one_hot_encode
 
@@ -11,23 +11,15 @@ from ...preprocess import one_hot_encode
 def test_one_hot_encode_basic():
     """Test basic functionality."""
 
-    data = {
-        "color": ["red", "blue", "green"],
-        "size": ["M", "L", "M"]
-    }
+    data = {"color": ["red", "blue", "green"], "size": ["M", "L", "M"]}
     df = pd.DataFrame(data)
 
-    expected_df = pd.DataFrame({
-        "color_green": [0, 0, 1],
-        "color_red": [1, 0, 0],
-        "size_M": [1, 0, 1]
-    })
+    expected_df = pd.DataFrame(
+        {"color_green": [0, 0, 1], "color_red": [1, 0, 0], "size_M": [1, 0, 1]}
+    )
 
     result = one_hot_encode(
-        df, 
-        columns=["color", "size"], 
-        drop_first=True, 
-        return_df=True
+        df, columns=["color", "size"], drop_first=True, return_df=True
     )
 
     pd.testing.assert_frame_equal(result, expected_df)
@@ -36,29 +28,15 @@ def test_one_hot_encode_basic():
 def test_one_hot_encode_return_df_false():
     """Test return type when `return_df` is False."""
 
-    data = {
-        "color": ["red", "blue", "green"],
-        "size": ["M", "L", "M"]
-    }
+    data = {"color": ["red", "blue", "green"], "size": ["M", "L", "M"]}
     df = pd.DataFrame(data)
 
     result, column_names = one_hot_encode(
-        df, 
-        columns=["color", "size"], 
-        drop_first=True, 
-        return_df=False
+        df, columns=["color", "size"], drop_first=True, return_df=False
     )
 
-    expected_array = np.array([
-        [0, 1, 1],
-        [0, 0, 0],
-        [1, 0, 1]
-    ])
-    expected_columns = [
-        "color_green", 
-        "color_red", 
-        "size_M"
-    ]
+    expected_array = np.array([[0, 1, 1], [0, 0, 0], [1, 0, 1]])
+    expected_columns = ["color_green", "color_red", "size_M"]
 
     np.testing.assert_array_equal(result, expected_array)
     assert column_names == expected_columns
@@ -67,25 +45,21 @@ def test_one_hot_encode_return_df_false():
 def test_one_hot_encode_drop_first():
     """Test if the "drop_first" option works correctly."""
 
-    data = {
-        "color": ["red", "blue", "green"],
-        "size": ["M", "L", "M"]
-    }
+    data = {"color": ["red", "blue", "green"], "size": ["M", "L", "M"]}
     df = pd.DataFrame(data)
 
-    expected_df_drop_first = pd.DataFrame({
-        "color_blue": [0, 1, 0],
-        "color_green": [0, 0, 1],
-        "color_red": [1, 0, 0],
-        "size_L": [0, 1, 0],
-        "size_M": [1, 0, 1]
-    })
+    expected_df_drop_first = pd.DataFrame(
+        {
+            "color_blue": [0, 1, 0],
+            "color_green": [0, 0, 1],
+            "color_red": [1, 0, 0],
+            "size_L": [0, 1, 0],
+            "size_M": [1, 0, 1],
+        }
+    )
 
     result = one_hot_encode(
-        df, 
-        columns=["color", "size"], 
-        drop_first=False, 
-        return_df=True
+        df, columns=["color", "size"], drop_first=False, return_df=True
     )
 
     pd.testing.assert_frame_equal(result, expected_df_drop_first)
@@ -95,24 +69,14 @@ def test_one_hot_encode_return_df_false_no_drop_first():
     """
     Test if the function works when `return_df` is False and `drop_first` is False.
     """
-    data = {
-        "color": ["red", "blue", "green"],
-        "size": ["M", "L", "M"]
-    }
+    data = {"color": ["red", "blue", "green"], "size": ["M", "L", "M"]}
     df = pd.DataFrame(data)
 
     result, column_names = one_hot_encode(
-        df, 
-        columns=["color", "size"], 
-        drop_first=False, 
-        return_df=False
+        df, columns=["color", "size"], drop_first=False, return_df=False
     )
 
-    expected_array = np.array([
-        [0, 0, 1, 0, 1],
-        [1, 0, 0, 1, 0],
-        [0, 1, 0, 0, 1]
-    ])
+    expected_array = np.array([[0, 0, 1, 0, 1], [1, 0, 0, 1, 0], [0, 1, 0, 0, 1]])
     expected_columns = ["color_blue", "color_green", "color_red", "size_L", "size_M"]
 
     np.testing.assert_array_equal(result, expected_array)
@@ -122,17 +86,9 @@ def test_one_hot_encode_return_df_false_no_drop_first():
 def test_one_hot_encode_no_categorical_columns():
     """Test the output when there are no categorical columns to encode."""
 
-    data = {
-        "age": [23, 45, 34],
-        "income": [50000, 60000, 55000]
-    }
+    data = {"age": [23, 45, 34], "income": [50000, 60000, 55000]}
     df = pd.DataFrame(data)
 
-    result = one_hot_encode(
-        df, 
-        columns=[], 
-        drop_first=True, 
-        return_df=True
-    )
+    result = one_hot_encode(df, columns=[], drop_first=True, return_df=True)
 
     pd.testing.assert_frame_equal(result, df)

--- a/turtles/stats/__init__.py
+++ b/turtles/stats/__init__.py
@@ -6,12 +6,11 @@ These functions support various statistical tasks.
 
 from ._stats import (
     calculate_errors,
-    variance_inflation_factor,
-    pearson_corr,
     covariance_matrix,
-    pca
+    pca,
+    pearson_corr,
+    variance_inflation_factor,
 )
-
 
 __all__ = [
     "glms",  # submodule
@@ -19,5 +18,5 @@ __all__ = [
     "variance_inflation_factor",
     "pearson_corr",
     "covariance_matrix",
-    "pca"
+    "pca",
 ]

--- a/turtles/stats/_stats.py
+++ b/turtles/stats/_stats.py
@@ -2,24 +2,18 @@
 Various statistical functions.
 """
 
-from typing import Optional, Tuple, Dict, List
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
-from scipy.stats import pearsonr
 from scipy.sparse.linalg import eigs
+from scipy.stats import pearsonr
 
-from .._utils import (
-    _validate_args,
-    _add_intercept,
-    _shape_check
-)
+from .._utils import _add_intercept, _shape_check, _validate_args
 
 
 def calculate_errors(
-    y_true: np.ndarray, 
-    y_pred: np.ndarray, 
-    m: Optional[int] = None
+    y_true: np.ndarray, y_pred: np.ndarray, m: Optional[int] = None
 ) -> Dict[str, float]:
     """
     Calculate errors for arrays containing continuous values. Not suitable
@@ -35,10 +29,10 @@ def calculate_errors(
         True target array. Must be the same shape as y_pred and have 1 dimension
         or be flattened.
     y_pred : np.ndarray
-        Predicted values target array. Must be the same shape as y_true and have 
+        Predicted values target array. Must be the same shape as y_true and have
         1 dimension or be flattened.
     m : int
-        Number of observations. If using this function to calculate model fit 
+        Number of observations. If using this function to calculate model fit
         statistics, 'm' should be the degrees of freedom.
 
     Returns
@@ -50,37 +44,32 @@ def calculate_errors(
     m = m or max(y_true.shape)
 
     _validate_args(
-        {
-            "y_true": (y_true, np.ndarray),
-            "y_pred": (y_pred, np.ndarray),
-            "m": (m, int)
-        }
+        {"y_true": (y_true, np.ndarray), "y_pred": (y_pred, np.ndarray), "m": (m, int)}
     )
 
     errors = y_true - y_pred
-    sse = np.sum(errors ** 2).item()
+    sse = np.sum(errors**2).item()
     mse = sse / m
     rmse = np.sqrt(mse).item()
 
     response = {
         "Sum of Squared Errors": sse,
         "Mean Squared Error": mse,
-        "Root Mean Squared Error": rmse
+        "Root Mean Squared Error": rmse,
     }
 
     return response
 
 
 def variance_inflation_factor(
-    X: np.ndarray,
-    var_names: Optional[List[str]] = None
+    X: np.ndarray, var_names: Optional[List[str]] = None
 ) -> pd.DataFrame:
     """
-    Calculate Variance Inflation Factor (VIF) for all predictors in the 
+    Calculate Variance Inflation Factor (VIF) for all predictors in the
     input matrix.
 
-    Fits one linear model for each dimension, where that single dimension 
-    is the dependent variable, and all other dimensions (including an intercept) 
+    Fits one linear model for each dimension, where that single dimension
+    is the dependent variable, and all other dimensions (including an intercept)
     are the independent variables.
 
     Parameters
@@ -88,8 +77,8 @@ def variance_inflation_factor(
     X : np.ndarray, shape (m, n)
         Design matrix. Should not include an intercept.
     var_names : Optional[List[str]]
-        Variable names. If not passed, defaults to `x_i` where `i` is the order 
-        of the dimension in the input matrix. Names must appear in the order 
+        Variable names. If not passed, defaults to `x_i` where `i` is the order
+        of the dimension in the input matrix. Names must appear in the order
         that they do in the input matrix.
 
     Returns
@@ -99,25 +88,17 @@ def variance_inflation_factor(
         VIF (float).
     """
 
-    _validate_args(
-        {
-            "X": (X, np.ndarray)
-        }
-    )
+    _validate_args({"X": (X, np.ndarray)})
     _shape_check(X, "X", 1)
 
-    vifs = {
-        "Coefficient": [],
-        "R-squared": [],
-        "VIF": []
-    }
+    vifs = {"Coefficient": [], "R-squared": [], "VIF": []}
 
     for idx in range(X.shape[1]):
         # create design matrix -- all except one predictor
         exog = np.delete(X, idx, axis=1)
         # target -- the one predictor
         endog = X[:, idx]
-        
+
         # add intercept to design matrix
         exog = _add_intercept(exog)
 
@@ -129,8 +110,8 @@ def variance_inflation_factor(
         residuals = endog - fitted_vals
 
         # Redisual Sum of Squares and Sum of Squares Total
-        rss = np.sum(residuals ** 2)
-        sst = np.sum((endog - np.mean(endog))**2)
+        rss = np.sum(residuals**2)
+        sst = np.sum((endog - np.mean(endog)) ** 2)
 
         # R-squared
         r2 = 1 - rss / sst
@@ -143,14 +124,14 @@ def variance_inflation_factor(
         vifs["Coefficient"].append(f"x{idx}")
 
     if var_names is not None:
-        vifs["Coefficient"] = var_names 
+        vifs["Coefficient"] = var_names
 
     return pd.DataFrame(vifs)
 
 
 def pearson_corr(
-    x: np.ndarray, 
-    y: np.ndarray, 
+    x: np.ndarray,
+    y: np.ndarray,
 ) -> Tuple[float, float]:
     """
     Calculate the Pearson Correlation Coefficient.
@@ -173,12 +154,7 @@ def pearson_corr(
         and the p-value in position [1].
     """
 
-    _validate_args(
-        {
-            "x": (x, np.ndarray),
-            "y": (y, np.ndarray)
-        }
-    )
+    _validate_args({"x": (x, np.ndarray), "y": (y, np.ndarray)})
 
     result = pearsonr(x=x.flatten(), y=y.flatten())
     return (result.statistic.item(), result.pvalue.item())
@@ -203,12 +179,7 @@ def covariance_matrix(X: np.ndarray, return_xc=False) -> np.ndarray:
         Centered input matrix.
     """
 
-    _validate_args(
-        {
-            "X": (X, np.ndarray),
-            "return_xc": (return_xc, bool)
-        }
-    )
+    _validate_args({"X": (X, np.ndarray), "return_xc": (return_xc, bool)})
     _shape_check(X, "X", 2)
 
     # estimate mean for each variable / column
@@ -220,11 +191,11 @@ def covariance_matrix(X: np.ndarray, return_xc=False) -> np.ndarray:
     X_c = X_t - avg[:, None]
 
     # covariance matrix
-    C = (X_c @ X_c.T)/m
+    C = (X_c @ X_c.T) / m
 
     if return_xc:
         return C, X_c
-    
+
     return C
 
 
@@ -237,13 +208,13 @@ def pca(X: np.ndarray, p: int) -> np.ndarray:
     X : np.ndarray, shape (M, N)
         Input data (design matrix) for calculating pricipal components.
     p : int
-        Number of principle components to return. Must be less than or 
+        Number of principle components to return. Must be less than or
         equal to the number of dimensions in X.
 
     Raises
     ------
     ValueError
-        If the requested number of principal components exceeds the number 
+        If the requested number of principal components exceeds the number
         of dimensions in the input matrix.
 
     Returns
@@ -252,12 +223,7 @@ def pca(X: np.ndarray, p: int) -> np.ndarray:
         Matrix with p dimensions.
     """
 
-    _validate_args(
-        {
-            "X": (X, np.ndarray),
-            "p": (p, int)
-        }
-    )
+    _validate_args({"X": (X, np.ndarray), "p": (p, int)})
     _shape_check(X, "X", 2)
 
     if p > X.shape[1]:

--- a/turtles/stats/glms/__init__.py
+++ b/turtles/stats/glms/__init__.py
@@ -2,13 +2,8 @@
 GLMs submodule.
 """
 
-from ._mlr import MLR
 from ._logreg import LogReg
+from ._mlr import MLR
 from ._poisson import PoissonReg
 
-
-__all__ = [
-    "MLR",
-    "LogReg",
-    "PoissonReg"
-]
+__all__ = ["MLR", "LogReg", "PoissonReg"]

--- a/turtles/stats/glms/_base.py
+++ b/turtles/stats/glms/_base.py
@@ -65,22 +65,14 @@ described above.
 """
 
 import warnings
-from typing import (
-    Optional, 
-    Literal, 
-    List,
-    Tuple
-)
+from typing import List, Literal, Optional, Tuple
 
 import numpy as np
-from scipy.stats import norm
-from scipy.optimize import fmin_l_bfgs_b
 import pandas as pd
+from scipy.optimize import fmin_l_bfgs_b
+from scipy.stats import norm
 
-from ..._utils import (
-    _validate_args,
-    _add_intercept
-)
+from ..._utils import _add_intercept, _validate_args
 from ._warnings import SingularityWarning
 
 _supported_methods = ["newton", "grad", "lbfgs"]
@@ -90,17 +82,17 @@ class GLM:
     """
     Parent class for GLM implementations.
 
-    Class Attributes and Methods are described in each child class 
+    Class Attributes and Methods are described in each child class
     implementation.
     """
 
     def __init__(
         self,
-        max_iter: int = 1000, 
+        max_iter: int = 1000,
         learning_rate: float = 0.1,
         tolerance: float = 0.000001,
         beta_momentum: float = 0.9,
-        method: Literal["newton", "grad", "lbfgs"] = "lbfgs"
+        method: Literal["newton", "grad", "lbfgs"] = "lbfgs",
     ):
         """
         Initialize the GLM with the specified hyperparameters.
@@ -110,25 +102,25 @@ class GLM:
         max_iter : Optional[int], default=1000
             The maximum number of iterations for the fitting algorithm.
         learning_rate : Optional[float], default=0.1
-            The learning rate (step size) used to update the model parameters 
+            The learning rate (step size) used to update the model parameters
             during the fitting algorithm. Only applicable for `grad` and `newton`.
         tolerance : float, default=0.000001
-            The tolerance for stopping the fitting algorithm when the change in 
-            model parameters is below this value. Only applicable for `grad` 
+            The tolerance for stopping the fitting algorithm when the change in
+            model parameters is below this value. Only applicable for `grad`
             and `newton`.
         beta_momentum : float, default=0.9
-            Momentum hyperparameter for the gradient descent update. Only used 
-            and required when method = 'grad'. A value of 0 is equivalent to 
+            Momentum hyperparameter for the gradient descent update. Only used
+            and required when method = 'grad'. A value of 0 is equivalent to
             standard gradient descent.
         method : Literal['newton', 'grad', 'lbfgs'], default 'lbfgs'.
-            Optimization method for fitting the model. Currently supported algorithms 
+            Optimization method for fitting the model. Currently supported algorithms
             are:
-                - `grad`: Gradient Descent (first-order). Requires hyperparameter 
+                - `grad`: Gradient Descent (first-order). Requires hyperparameter
                   tuning (`learning_rate`, `tolerance`, `beta_momentum`, `max_iter`).
-                - `newton`: Newton's Method (second-order). Requires hyperparameter 
+                - `newton`: Newton's Method (second-order). Requires hyperparameter
                   tuning (`learning_rate`, `tolerance`, `max_iter`).
-                - `lbfgs`: Low-memory Broyden-Fletcher-Goldfarb-Shanno algorithm 
-                  (quasi-Newton). Does not require hyperparameter tuning; only uses 
+                - `lbfgs`: Low-memory Broyden-Fletcher-Goldfarb-Shanno algorithm
+                  (quasi-Newton). Does not require hyperparameter tuning; only uses
                   `max_iter`.
         """
 
@@ -144,9 +136,9 @@ class GLM:
 
         # additional input checks
         for args in [
-            ("max_iter", max_iter), 
-            ("learning_rate", learning_rate), 
-            ("tolerance", tolerance), 
+            ("max_iter", max_iter),
+            ("learning_rate", learning_rate),
+            ("tolerance", tolerance),
             ("beta_momentum", beta_momentum),
         ]:
             if args[0] == "tolerance" and (args[1] <= 0) and (args[1] >= 1):
@@ -192,129 +184,124 @@ class GLM:
     def observations(self) -> float:
         self._is_fit()
         return self._m
-    
+
     @property
     def dimensions(self) -> float:
         self._is_fit()
         return self._n
-    
+
     @property
     def degrees_of_freedom(self) -> int:
         self._is_fit()
         return self._dof
-    
+
     @property
     def betas(self) -> np.ndarray:
         self._is_fit()
         return self._betas
-    
+
     @property
     def iterations(self) -> float:
         self._is_fit()
         return self._iterations
-    
+
     @property
     def last_gradient(self) -> np.ndarray:
         self._is_fit()
         return self._gradient
-    
+
     @property
     def last_velocity(self) -> np.ndarray:
         self._is_fit()
         return self._velocity
-    
+
     @property
     def std_error_betas(self) -> np.ndarray:
         self._is_fit()
         return self._std_error_betas
-    
+
     @property
     def z_stat_betas(self) -> np.ndarray:
         self._is_fit()
         return self._z_stat_betas
-    
+
     @property
     def p_values(self) -> np.ndarray:
         self._is_fit()
         return self._p_values
-    
+
     @property
     def critical_z(self) -> float:
         self._is_fit()
         return self._critical_z
-    
+
     @property
     def confidence_interval(self) -> Tuple[np.ndarray, np.ndarray]:
         self._is_fit()
         return self._confidence_interval
-    
+
     # ----- CHILD CLASS INSTANCE METHODS -----
-    
-    def _objective_func(self, 
-        betas: np.ndarray, 
-        X: np.ndarray, 
-        y: np.ndarray
+
+    def _objective_func(
+        self, betas: np.ndarray, X: np.ndarray, y: np.ndarray
     ) -> float:  # pragma: no cover
         """
-        Compute the negative log-likelihood for the GLM. This is the objective 
+        Compute the negative log-likelihood for the GLM. This is the objective
         function we want to minimize in the scipy L-BFGS solver.
 
-        The function parameters MUST be in the specified order: betas, X, y. 
-        These are ALWAYS required. The L-BFGS solver passes positional arguments 
-        to this function in this exact order. If the child class requires a 
-        parameter like exposure, it must be placed last to maintain the proper 
+        The function parameters MUST be in the specified order: betas, X, y.
+        These are ALWAYS required. The L-BFGS solver passes positional arguments
+        to this function in this exact order. If the child class requires a
+        parameter like exposure, it must be placed last to maintain the proper
         order.
 
         This instance method must be implemented in the child class.
         """
         pass
-        
+
     def _link_func(self, y: np.ndarray) -> np.ndarray:  # pragma: no cover
         """
-        Link function for the GLM child class. 
-        
+        Link function for the GLM child class.
+
         This instance method must be implemented in the child class.
         """
         pass
 
     def _grad_func(
-        self, 
-        betas: np.ndarray,
-        X: np.ndarray, 
-        y: np.ndarray
+        self, betas: np.ndarray, X: np.ndarray, y: np.ndarray
     ) -> np.ndarray:  # pragma: no cover
         """
-        Gradient calculation function for the GLM child class (i.e., the first 
+        Gradient calculation function for the GLM child class (i.e., the first
         derivative of the loss function with respect to the model parameters).
 
-        The function parameters MUST be in the specified order: betas, X, y. 
-        These are ALWAYS required. The L-BFGS solver passes positional arguments 
-        to this function in this exact order. If the child class requires a 
-        parameter like exposure, it must be placed last to maintain the proper 
+        The function parameters MUST be in the specified order: betas, X, y.
+        These are ALWAYS required. The L-BFGS solver passes positional arguments
+        to this function in this exact order. If the child class requires a
+        parameter like exposure, it must be placed last to maintain the proper
         order.
-        
+
         This instance method must be implemented in the child class.
         """
         pass
 
     def _hess_func(self, X: np.ndarray) -> np.ndarray:  # pragma: no cover
         """
-        Hessian calculation function for the GLM child class (i.e., the second 
-        derivative of the loss function with respect to the model parameters). 
-        
+        Hessian calculation function for the GLM child class (i.e., the second
+        derivative of the loss function with respect to the model parameters).
+
         This instance method must be implemented in the child class.
         """
         pass
 
     # ----- IMPLEMENTED INSTANCE METHODS -----
-    
+
     def _is_fit(self):
         """
         Check if the model is fit by calling a property that's only
         set in the 'fit()' method.
 
         This is used to help ensure the model has been fit before the
-        user can call certain instance methods and attributes. 
+        user can call certain instance methods and attributes.
 
         Raises
         ------
@@ -322,10 +309,8 @@ class GLM:
             If the class instance has not been fit.
         """
         if not self._fitted:
-            raise Warning(
-                "Please fit the model before calling this method/property."
-            )
-        
+            raise Warning("Please fit the model before calling this method/property.")
+
     def _get_hessian_inv(self, H: np.ndarray) -> np.ndarray:
         """
         Compute the inverse of the Hessian matrix.
@@ -338,7 +323,7 @@ class GLM:
         Raises
         ------
         SingularityWarning
-            If the Hessian matrix is singular and the inverse cannot be computed. 
+            If the Hessian matrix is singular and the inverse cannot be computed.
             This may happen if the hyperparameters are not tuned properly, or
             multicollinearity exists.
 
@@ -359,50 +344,52 @@ class GLM:
             )
             hessian_inv = np.linalg.pinv(H)
         return hessian_inv
-    
+
     def _gradient_descent(self, **kwargs):
         """
-        Momentum-based Gradient Descent for updating betas. Uses the child class 
+        Momentum-based Gradient Descent for updating betas. Uses the child class
         implementation of the Gradient, `_grad_func()`.
 
         Parameters
         ----------
         **kwargs
             X : np.ndarray, shape (M, N)
-                The input design matrix, where M is the number of samples and N 
+                The input design matrix, where M is the number of samples and N
                 is the number of features.
             y : np.ndarray, shape (M, 1)
                 The true target values for each sample in the dataset.
             exposure : Optional[np.ndarray], shape (M, 1)
-                The exposure values for each sample. Only applicable for GLMs 
+                The exposure values for each sample. Only applicable for GLMs
                 that use exposure.
 
         Returns
         -------
         None
         """
-        # send kwargs to child class _grad_func(), which may 
+        # send kwargs to child class _grad_func(), which may
         # contain varying parameters
         self._gradient = self._grad_func(self._betas, **kwargs)
-        self._velocity = self.beta_momentum * self._velocity + \
-            (1 - self.beta_momentum) * self._gradient
+        self._velocity = (
+            self.beta_momentum * self._velocity
+            + (1 - self.beta_momentum) * self._gradient
+        )
         self._betas -= self.learning_rate * self._velocity
 
     def _newtons_method(self, **kwargs):
         """
-        Newtons Method for updating betas. Uses the child class implementation 
+        Newtons Method for updating betas. Uses the child class implementation
         of the Gradient and Hessian, `_grad_func()` and `_hess_func()`.
 
         Parameters
         ----------
         **kwargs
             X : np.ndarray, shape (M, N)
-                The input design matrix, where M is the number of samples and 
+                The input design matrix, where M is the number of samples and
                 N is the number of features.
             y : np.ndarray, shape (M, 1)
                 The true target values for each sample in the dataset.
             exposure : Optional[np.ndarray], shape (M, 1)
-                The exposure values for each sample. Only applicable for GLMs 
+                The exposure values for each sample. Only applicable for GLMs
                 that use exposure.
 
         Returns
@@ -419,15 +406,15 @@ class GLM:
         Performs optimization using the L-BFGS-B algorithm.
 
         This method uses the L-BFGS-B (Limited-memory Broyden-Fletcher-Goldfarb-
-        Shanno with Box constraints) algorithm from `scipy.optimize` to minimize 
+        Shanno with Box constraints) algorithm from `scipy.optimize` to minimize
         an objective function and estimate the optimal coefficients.
 
-        This method is good for large datasets because it typically converges 
+        This method is good for large datasets because it typically converges
         quickly.
 
-        NOTE: The L-BFGS solver implements its own procedure internally; thus 
-        we set the `_iterations` and `_betas` attributes based on its results. 
-        We also mark the model as "fitted" to terminate the `_optimization()` 
+        NOTE: The L-BFGS solver implements its own procedure internally; thus
+        we set the `_iterations` and `_betas` attributes based on its results.
+        We also mark the model as "fitted" to terminate the `_optimization()`
         method.
 
         https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.fmin_l_bfgs_b.html
@@ -436,13 +423,13 @@ class GLM:
         ----------
         **kwargs
             X : np.ndarray, shape (M, N)
-                The input design matrix, where M is the number of samples and 
-                N is the 
+                The input design matrix, where M is the number of samples and
+                N is the
                 number of features.
             y : np.ndarray, shape (M, 1)
                 The true target values for each sample in the dataset.
             exposure : Optional[np.ndarray], shape (M, 1)
-                The exposure values for each sample. Only applicable for GLMs 
+                The exposure values for each sample. Only applicable for GLMs
                 that use exposure.
 
         Returns
@@ -455,42 +442,42 @@ class GLM:
         y = kwargs.get("y").flatten()
         exposure = kwargs.get("exposure", None)
         args = (X, y, exposure.flatten()) if exposure is not None else (X, y)
-        
+
         result = fmin_l_bfgs_b(
-            func=self._objective_func, 
-            x0=self._betas.flatten(), 
-            fprime=self._grad_func, 
-            args=args, 
+            func=self._objective_func,
+            x0=self._betas.flatten(),
+            fprime=self._grad_func,
+            args=args,
             approx_grad=False,
-            maxiter=self.max_iter
+            maxiter=self.max_iter,
         )
 
         # extract results
-        self._betas = result[0].reshape(1, self._n+1)
+        self._betas = result[0].reshape(1, self._n + 1)
         self._fitted = True
         self._iterations = result[2]["nit"]
-        
+
     def _optimization(self, **kwargs):
         """
         Perform the specified algorithm to estimate model parameters.
 
-        This method iteratively updates the model parameters (betas) with the 
-        goal of minimizing the loss function. The process continues until 
-        convergence criteria are met: either the maximum number of iterations 
+        This method iteratively updates the model parameters (betas) with the
+        goal of minimizing the loss function. The process continues until
+        convergence criteria are met: either the maximum number of iterations
         or a change in the betas below a specified tolerance.
 
-        The **kwargs passed to this function are passed to the appropriate 
+        The **kwargs passed to this function are passed to the appropriate
         algorithm function.
 
-        NOTE: The L-BFGS solver implements its own procedure internally. We 
-        terminate the `_optimization()` function once its complete, using the 
+        NOTE: The L-BFGS solver implements its own procedure internally. We
+        terminate the `_optimization()` function once its complete, using the
         `_fitted` attribute.
 
         Parameters
         ----------
         **kwargs
             X : np.ndarray, shape (M, N)
-                The input design matrix, where M is the number of samples and 
+                The input design matrix, where M is the number of samples and
                 N is the number of features.
             y : np.ndarray, shape (M, 1)
                 The true target values for each sample in the dataset.
@@ -504,7 +491,7 @@ class GLM:
         algo_map = {
             "grad": self._gradient_descent,
             "newton": self._newtons_method,
-            "lbfgs": self._l_bfgs
+            "lbfgs": self._l_bfgs,
         }
         update_betas = algo_map.get(self.method)
 
@@ -517,10 +504,10 @@ class GLM:
 
             # strict convergence check
             if (
-                np.max(np.abs(self._betas - prev_betas)
-            ) < self.tolerance) or self._fitted:
+                np.max(np.abs(self._betas - prev_betas)) < self.tolerance
+            ) or self._fitted:
                 break
-            
+
             self._iterations += 1
 
         self._fitted = True
@@ -529,8 +516,8 @@ class GLM:
         """
         Calculate the Standard Error for the estimated model coefficients.
 
-        The Covariance Matrix is equal to the inverse of the Hessian matrix, 
-        and the Standard Errors of the estimated model coefficients are equal 
+        The Covariance Matrix is equal to the inverse of the Hessian matrix,
+        and the Standard Errors of the estimated model coefficients are equal
         to the square root of the Covariance Matrix diagonals.
 
         Parameters
@@ -547,10 +534,10 @@ class GLM:
         # covariance matrix is the hessian inverse
         self._covariance = self._get_hessian_inv(H)
         # std errors are the square roots of the diagonal elements
-        self._std_error_betas = np.sqrt(
-            np.diagonal(np.abs(self._covariance))
-        ).reshape(1, self._n + 1)
-        
+        self._std_error_betas = np.sqrt(np.diagonal(np.abs(self._covariance))).reshape(
+            1, self._n + 1
+        )
+
     def _get_coef_stats(self, X: np.ndarray, y: np.ndarray):
         """
         Calculate statistics for the model coefficient estimates.
@@ -582,7 +569,7 @@ class GLM:
         self._p_values = 2 * (1 - norm.cdf(np.abs(self._z_stat_betas)))
 
         # use norm-dist PPF to get critical z-value at 95% confidence
-        self._critical_z = norm.ppf(1 - 0.05/2)
+        self._critical_z = norm.ppf(1 - 0.05 / 2)
 
         # confidence interval
         self._confidence_interval = (
@@ -591,39 +578,39 @@ class GLM:
         )
 
     def fit(
-        self, 
-        X: np.ndarray, 
+        self,
+        X: np.ndarray,
         y: np.ndarray,
         exposure: Optional[np.ndarray] = None,
-        var_names: Optional[List[str]] = []
+        var_names: Optional[List[str]] = [],
     ):
         """
-        Fit the model using the optimization 'method' specified during class 
+        Fit the model using the optimization 'method' specified during class
         instantiation.
 
         Parameters
         ----------
         X : np.ndarray, shape (M, N)
-            The input design matrix, where M is the number of samples and N 
+            The input design matrix, where M is the number of samples and N
             is the number of features. This should not include the intercept.
         y : np.ndarray, shape (M, 1)
             The true target values for each sample in the dataset.
         exposure : Optional[np.ndarray], shape (M, 1)
-            The exposure values for each sample. These represent the varying 
-            exposure times, population sizes, or different rates of observation, 
-            which are used to scale the predicted values. It is a vector of size 
+            The exposure values for each sample. These represent the varying
+            exposure times, population sizes, or different rates of observation,
+            which are used to scale the predicted values. It is a vector of size
             M containing the exposure values. Not applicable for all GLMs.
         var_names : Optional[List[Union[str, None]]]
-            Optional list of variable names. List must be in the same order that 
-            the variables appear in the design matrix. 'Intercept' should not 
+            Optional list of variable names. List must be in the same order that
+            the variables appear in the design matrix. 'Intercept' should not
             be included in the list.
 
         Raises
         ------
         ValueError
-            If the length of `var_names` does not equal the number of dimensions 
+            If the length of `var_names` does not equal the number of dimensions
             in the input matrix.
-        
+
         Returns
         -------
         None
@@ -634,7 +621,7 @@ class GLM:
                 "X": (X, np.ndarray),
                 "y": (y, np.ndarray),
                 "var_names": (var_names, list),
-                "exposure": (exposure, (np.ndarray, type(None)))
+                "exposure": (exposure, (np.ndarray, type(None))),
             }
         )
 
@@ -644,23 +631,20 @@ class GLM:
             raise ValueError(
                 "'var_names' length must be equal to the design matrix dimensions."
             )
-        
+
         # set instance attributes
         self.variable_names = var_names
         self._dof = self._m - self._n - 1
 
         # initialize
-        X = _add_intercept(X) 
+        X = _add_intercept(X)
         self._betas = np.zeros((1, self._n + 1))
 
         if self.method == "grad":
             self._velocity = np.zeros_like(self._betas)
 
         # deliver args for optimization; pass exposure, if needed
-        package = {
-            "X": X,
-            "y": y
-        }
+        package = {"X": X, "y": y}
         if self._has_exposure:
             exposure = exposure if exposure is not None else np.ones_like(y)
             package["exposure"] = exposure
@@ -675,16 +659,16 @@ class GLM:
         """
         Predict the target values for the given input data.
 
-        The model makes predictions using the learned intercept and coefficients. 
-        Predicted values are transformed into the appropriate response using 
+        The model makes predictions using the learned intercept and coefficients.
+        Predicted values are transformed into the appropriate response using
         the child class implementation of the `_link_func()`.
 
         Parameters
         ----------
         X : np.ndarray, shape (M, N)
             Design matrix with N rows (samples) and N columns (features).
-            The number of columns (N) must match the number of coefficients. 
-            The design matrix should not include the intercept; it is added 
+            The number of columns (N) must match the number of coefficients.
+            The design matrix should not include the intercept; it is added
             within this class method.
 
         Returns
@@ -695,12 +679,8 @@ class GLM:
 
         self._is_fit()
 
-        _validate_args(
-            {
-                "X": (X, np.ndarray)
-            }
-        )
-        
+        _validate_args({"X": (X, np.ndarray)})
+
         X = _add_intercept(X)
         return self._link_func(X @ self._betas.T)
 
@@ -724,9 +704,7 @@ class GLM:
 
         self._is_fit()
 
-        names = self.variable_names or [
-            f"x{i}" for i in range(self._n)
-        ]
+        names = self.variable_names or [f"x{i}" for i in range(self._n)]
         stats = {
             "Variable": ["Intercept"] + names,
             "Coefficient": self._betas[0],
@@ -734,7 +712,6 @@ class GLM:
             "z-statistic": self._z_stat_betas[0],
             "p-value": self._p_values[0],
             "[0.025": self._confidence_interval[0][0],
-            "0.075]": self._confidence_interval[1][0]
+            "0.075]": self._confidence_interval[1][0],
         }
         return pd.DataFrame(stats).round(4)
-    

--- a/turtles/stats/glms/_logreg.py
+++ b/turtles/stats/glms/_logreg.py
@@ -18,11 +18,11 @@ class LogReg(GLM):
         2. Independence:
             [y_i, y_i+1, ..., y_n] are independent random variables.
         3. Logit Link Function:
-            We link the probability of success to the predicting variables via 
+            We link the probability of success to the predicting variables via
             the 'logit' link function.
 
-    The design matrix used to fit the model, X, has M rows and N dimensions, 
-    excluding the intercept. I.e., it has shape (M, N), or (M, N+1) with the 
+    The design matrix used to fit the model, X, has M rows and N dimensions,
+    excluding the intercept. I.e., it has shape (M, N), or (M, N+1) with the
     intercept.
 
     Regularization is not currently supported.
@@ -32,30 +32,30 @@ class LogReg(GLM):
     max_iter : Optional[int], default=1000
         The maximum number of iterations for the fitting algorithm.
     learning_rate : Optional[float], default=0.01
-        The learning rate (step size) used to update the model parameters during 
+        The learning rate (step size) used to update the model parameters during
         the fitting algorithm. Only applicable for `grad` and `newton`.
     tolerance : float, default=0.001
-        The tolerance for stopping the fitting algorithm when the change in model 
+        The tolerance for stopping the fitting algorithm when the change in model
         parameters is below this value. Only applicable for `grad` and `newton`.
     beta_momentum : float, default=0.9
-        Momentum hyperparameter for the gradient descent update. Only used and 
-        required when method = 'grad'. A value of 0 is equivalent to standard 
+        Momentum hyperparameter for the gradient descent update. Only used and
+        required when method = 'grad'. A value of 0 is equivalent to standard
         gradient descent.
     method : Literal['newton', 'grad', 'lbfgs'], default 'lbfgs'.
-        Optimization method for fitting the model. Currently supported algorithms 
+        Optimization method for fitting the model. Currently supported algorithms
         are:
-            - `grad`: Gradient Descent (first-order). Requires hyperparameter 
+            - `grad`: Gradient Descent (first-order). Requires hyperparameter
               tuning (`learning_rate`, `tolerance`, `beta_momentum`, `max_iter`).
-            - `newton`: Newton's Method (second-order). Requires hyperparameter 
+            - `newton`: Newton's Method (second-order). Requires hyperparameter
               tuning (`learning_rate`, `tolerance`, `max_iter`).
-            - `lbfgs`: Low-memory Broyden-Fletcher-Goldfarb-Shanno algorithm 
-              (quasi-Newton). Does not require hyperparameter tuning; only uses 
+            - `lbfgs`: Low-memory Broyden-Fletcher-Goldfarb-Shanno algorithm
+              (quasi-Newton). Does not require hyperparameter tuning; only uses
               `max_iter`.
     iterations : int
         The number of iterations performed by the optimization algorithm.
     betas : np.ndarray, shape (1, N+1)
-        The model parameters (coefficients) learned during the fitting process, 
-        where N is the number of features. The element is position [0] is the 
+        The model parameters (coefficients) learned during the fitting process,
+        where N is the number of features. The element is position [0] is the
         intercept.
     observations : int
         Number of observations in the design matrix.
@@ -64,43 +64,38 @@ class LogReg(GLM):
     std_error_betas : np.ndarray, shape (1, N+1)
         The standard errors of the estimated model coefficients.
     last_gradient : np.ndarray, shape (1, N+1)
-        The gradient vector from the last iteration of the optimization algorithm. 
+        The gradient vector from the last iteration of the optimization algorithm.
         Not applicable for the L-BFGS algorithm.
     last_velocity : np.ndarray, shape (1, N+1)
-        The velocity vector from the last iteration of the optimization algorithm. 
+        The velocity vector from the last iteration of the optimization algorithm.
         Only used in momentum-based optimization methods like gradient descent.
     z_stat_betas : np.ndarray, shape (1, N+1)
         The z-statistics for the estimated model coefficients.
     p_values : np.ndarray, shape (1, N+1)
-        The p-values corresponding to the z-statistics for the estimated model 
+        The p-values corresponding to the z-statistics for the estimated model
         coefficients.
     critical_z : float
-        The critical z-value for the estimated model coefficients, based on a 
+        The critical z-value for the estimated model coefficients, based on a
         95% confidence level.
     confidence_interval : Tuple[np.ndarray, np.ndarray]
         95% confidence interval for the estimated model coefficients.
     degrees_of_freedom : int
         Degrees of Freedom. Calculated as (observations - dimensions - 1).
-    
+
     Methods
     -------
     fit(X, y)
         Fit the Poisson regression model to the input data.
     predict(X)
-        Predict the target values (counts) for the input data based on the 
+        Predict the target values (counts) for the input data based on the
         fitted model coefficients.
     summary()
         Generate a model summary table.
     """
 
-    def _objective_func(
-        self, 
-        betas: np.ndarray, 
-        X: np.ndarray, 
-        y: np.ndarray
-    ) -> float:
+    def _objective_func(self, betas: np.ndarray, X: np.ndarray, y: np.ndarray) -> float:
         """
-        Compute the negative log-likelihood for Logistic regression. This is 
+        Compute the negative log-likelihood for Logistic regression. This is
         the objective function we want to minimize in the scipy L-BFGS solver.
 
         Parameters
@@ -108,10 +103,10 @@ class LogReg(GLM):
         betas : np.ndarray, shape (1, N+1)
             The estimated model coefficients including the intercept (position [0]).
         X : np.ndarray, shape (M, N)
-            The input design matrix, where M is the number of samples and N is 
+            The input design matrix, where M is the number of samples and N is
             the number of features.
         y : np.ndarray, shape (M, 1)
-            The true target values for each sample in the dataset. It is a vector 
+            The true target values for each sample in the dataset. It is a vector
             of size M containing the counts.
 
         Returns
@@ -121,38 +116,33 @@ class LogReg(GLM):
         """
         p = self._link_func(X @ betas.T)
         return -np.sum(y * np.log(p) + (1 - y) * np.log(1 - p))
-        
+
     def _link_func(self, y: np.ndarray) -> np.ndarray:
         """
-        Compute the sigmoid (logistic) function applied to a linear 
+        Compute the sigmoid (logistic) function applied to a linear
         combination of features.
 
         Parameters
         ----------
         y : np.ndarray, shape (M, 1)
-            Fitted values, computed as the dot product of the design matrix 
+            Fitted values, computed as the dot product of the design matrix
             and the estimated model coefficients.
 
         Returns
         -------
         np.ndarray, shape (M, 1)
-            The output of the sigmoid function applied to the fitted values, 
+            The output of the sigmoid function applied to the fitted values,
             where each element represents a probability.
         """
         return 1 / (1 + np.exp(-y))
-    
-    def _grad_func(
-        self, 
-        betas: np.ndarray,
-        X: np.ndarray, 
-        y: np.ndarray
-    ) -> np.ndarray:
+
+    def _grad_func(self, betas: np.ndarray, X: np.ndarray, y: np.ndarray) -> np.ndarray:
         """
-        Compute the Gradient (first derivative) of the log-likelihood loss function 
+        Compute the Gradient (first derivative) of the log-likelihood loss function
         with respect to the model parameters.
 
-        Calculating the Gradient is the first step of each iteration during model 
-        fitting. As such, we set the 'self._current_sigmoid' instance attribute 
+        Calculating the Gradient is the first step of each iteration during model
+        fitting. As such, we set the 'self._current_sigmoid' instance attribute
         so it can be used by second-order methods during each iteration.
 
         Parameters
@@ -160,24 +150,24 @@ class LogReg(GLM):
         betas : np.ndarray, shape (1, N+1)
             The estimated model coefficients including the intercept (position [0]).
         X : np.ndarray, shape (M, N)
-            The input design matrix, where M is the number of samples and N is 
+            The input design matrix, where M is the number of samples and N is
             the number of features.
         y : np.ndarray, shape (M, 1)
-            The true target values for each sample in the dataset. It is a vector 
+            The true target values for each sample in the dataset. It is a vector
             of size M containing the counts.
 
         Returns
         -------
         np.ndarray, shape (1, N)
-            The Gradient of the loss function with respect to the model parameters 
-            (betas), which will be used to update the model parameters during 
+            The Gradient of the loss function with respect to the model parameters
+            (betas), which will be used to update the model parameters during
             model fitting.
         """
         # sigmoid (M, 1), gradient (N, 1)
         self._current_sigmoid = self._link_func(X @ betas.T)
         gradient = X.T @ (y - self._current_sigmoid)
         return -gradient.T
-    
+
     def _hess_func(self, X: np.ndarray) -> np.ndarray:
         """
         Compute the Hessian (second derivative) of the log-likelihood loss function
@@ -186,7 +176,7 @@ class LogReg(GLM):
         Parameters
         ----------
         X : np.ndarray, shape (M, N)
-            The input design matrix, where M is the number of samples and N is 
+            The input design matrix, where M is the number of samples and N is
             the number of features.
 
         Returns
@@ -195,5 +185,4 @@ class LogReg(GLM):
             The Hessian matrix.
         """
         diag_elements = self._current_sigmoid * (1 - self._current_sigmoid)
-        return -X.T * diag_elements.flatten() @ X  
-    
+        return -X.T * diag_elements.flatten() @ X

--- a/turtles/stats/glms/_warnings.py
+++ b/turtles/stats/glms/_warnings.py
@@ -7,4 +7,5 @@ class SingularityWarning(UserWarning):
     """
     Custom warning for issues related to singular matrices.
     """
+
     pass

--- a/turtles/stats/glms/_warnings.py
+++ b/turtles/stats/glms/_warnings.py
@@ -1,0 +1,10 @@
+"""
+Custom warnings class.
+"""
+
+
+class SingularityWarning(UserWarning):
+    """
+    Custom warning for issues related to singular matrices.
+    """
+    pass

--- a/turtles/stats/glms/tests/test_logreg.py
+++ b/turtles/stats/glms/tests/test_logreg.py
@@ -9,12 +9,10 @@ correctly.
 """
 
 import numpy as np
-import pandas as pd
-from sklearn.datasets import load_breast_cancer
 import statsmodels.api as sm
+from sklearn.datasets import load_breast_cancer
 
 from turtles.stats.glms import LogReg
-
 
 # we'll increase the tolerance a bit because the models are fit using MLE
 tol = 1e-4
@@ -55,28 +53,8 @@ def test_logreg():
     assert all([col in summary["Variable"].unique() for col in var_names])
     assert model.observations == sm_model.nobs
     assert model.degrees_of_freedom == sm_model.df_resid
-    np.isclose(
-        model.betas[0],
-        sm_model.params,
-        atol=tol
-    )
-    np.isclose(
-        model.p_values[0],
-        sm_model.pvalues,
-        atol=tol
-    )
-    np.isclose(
-        model.std_error_betas[0],
-        sm_model.bse,
-        atol=tol
-    )
-    np.isclose(
-        model.z_stat_betas[0],
-        sm_model.tvalues,
-        atol=tol
-    )
-    np.isclose(
-        preds,
-        sm_preds,
-        atol=tol
-    )
+    np.isclose(model.betas[0], sm_model.params, atol=tol)
+    np.isclose(model.p_values[0], sm_model.pvalues, atol=tol)
+    np.isclose(model.std_error_betas[0], sm_model.bse, atol=tol)
+    np.isclose(model.z_stat_betas[0], sm_model.tvalues, atol=tol)
+    np.isclose(preds, sm_preds, atol=tol)

--- a/turtles/stats/glms/tests/test_mlr.py
+++ b/turtles/stats/glms/tests/test_mlr.py
@@ -8,14 +8,13 @@ This is just a simple way of ensuring the MLR class calculates the core model re
 correctly.
 """
 
-import pytest
 import numpy as np
+import pytest
 import statsmodels.api as sm
-from sklearn.datasets import load_diabetes
 from scipy.stats import t
+from sklearn.datasets import load_diabetes
 
 from turtles.stats.glms import MLR
-
 
 tol = 1e-5
 prec = 5
@@ -40,7 +39,7 @@ sm_preds = sm_model.predict(X)
 
 # calculate critical t-value
 # SM OLS models don't offer this property
-sm_critical_t = t.ppf(1 - 0.05/2, sm_model.df_resid)
+sm_critical_t = t.ppf(1 - 0.05 / 2, sm_model.df_resid)
 
 
 def test_mlr():
@@ -68,7 +67,7 @@ def test_mlr():
         19. Estimated Coefficient t-stats
         20. Estimated Coefficient Standard Errors
         21. Model predictions (to ensure .predict() works)
-    
+
     Other tests:
 
         22. _is_fit()
@@ -83,101 +82,31 @@ def test_mlr():
     assert model.dimensions == X.shape[1] - 1
     assert model.degrees_of_freedom == sm_model.df_resid
 
+    assert np.isclose(model.intercept, sm_model.params[0], atol=tol).all()
+    assert np.isclose(model.betas[0], sm_model.params, atol=tol).all()
+    assert np.isclose(model.residuals.flatten(), sm_model.resid, atol=tol).all()
+    assert np.isclose(model.variance, sm_model.scale, atol=tol).all()
+    assert np.isclose(model.rss, sm_model.ssr, atol=tol).all()
+    assert np.isclose(model.rmse, np.sqrt(sm_model.mse_resid), atol=tol).all()
     assert np.isclose(
-        model.intercept,
-        sm_model.params[0],
-        atol=tol
+        model.std_residuals.flatten(), sm_model.resid_pearson, atol=tol
+    ).all()
+    assert np.isclose(model.covariance, sm_model.cov_params(), atol=tol).all()
+    assert np.isclose(model.critical_t, sm_critical_t, atol=tol).all()
+    assert np.isclose(
+        model.confidence_interval[0][0], sm_model.conf_int()[:, 0], atol=tol
     ).all()
     assert np.isclose(
-        model.betas[0],
-        sm_model.params,
-        atol=tol
+        model.confidence_interval[1][0], sm_model.conf_int()[:, 1], atol=tol
     ).all()
-    assert np.isclose(
-        model.residuals.flatten(),
-        sm_model.resid,
-        atol=tol
-    ).all()
-    assert np.isclose(
-        model.variance,
-        sm_model.scale,
-        atol=tol
-    ).all()
-    assert np.isclose(
-        model.rss,
-        sm_model.ssr,
-        atol=tol
-    ).all()
-    assert np.isclose(
-        model.rmse,
-        np.sqrt(sm_model.mse_resid),
-        atol=tol
-    ).all()
-    assert np.isclose(
-        model.std_residuals.flatten(),
-        sm_model.resid_pearson,
-        atol=tol
-    ).all()
-    assert np.isclose(
-        model.covariance,
-        sm_model.cov_params(),
-        atol=tol
-    ).all()
-    assert np.isclose(
-        model.critical_t,
-        sm_critical_t,
-        atol=tol
-    ).all()
-    assert np.isclose(
-        model.confidence_interval[0][0],
-        sm_model.conf_int()[:,0],
-        atol=tol
-    ).all()
-    assert np.isclose(
-        model.confidence_interval[1][0],
-        sm_model.conf_int()[:,1],
-        atol=tol
-    ).all()
-    assert np.isclose(
-        model.sst,
-        sm_model.centered_tss,
-        atol=tol
-    ).all()
-    assert np.isclose(
-        model.mse, 
-        sm_model.mse_resid,
-        atol=tol
-    )
-    assert np.isclose(
-        model.p_values[0],
-        sm_model.pvalues,
-        atol=tol
-    ).all()
-    assert np.isclose(
-        model.r2, 
-        sm_model.rsquared,
-        atol=tol
-    ).all()
-    assert np.isclose(
-        model.r2_adj, 
-        sm_model.rsquared_adj,
-        atol=tol
-    ).all()
-    assert np.isclose(
-        model.t_stat_betas[0],
-        sm_model.tvalues,
-        atol=tol
-    ).all()
-    assert np.isclose(
-        model.std_error_betas[0],
-        sm_model.bse,
-        atol=tol
-    ).all()
-    assert np.isclose(
-        preds.flatten(),
-        sm_preds,
-        atol=tol
-    ).all()
+    assert np.isclose(model.sst, sm_model.centered_tss, atol=tol).all()
+    assert np.isclose(model.mse, sm_model.mse_resid, atol=tol)
+    assert np.isclose(model.p_values[0], sm_model.pvalues, atol=tol).all()
+    assert np.isclose(model.r2, sm_model.rsquared, atol=tol).all()
+    assert np.isclose(model.r2_adj, sm_model.rsquared_adj, atol=tol).all()
+    assert np.isclose(model.t_stat_betas[0], sm_model.tvalues, atol=tol).all()
+    assert np.isclose(model.std_error_betas[0], sm_model.bse, atol=tol).all()
+    assert np.isclose(preds.flatten(), sm_preds, atol=tol).all()
 
     # ----- General testing -----
 

--- a/turtles/stats/glms/tests/test_poissonreg.py
+++ b/turtles/stats/glms/tests/test_poissonreg.py
@@ -8,14 +8,12 @@ just a simply way of ensuring the PoissonReg class calculates the core model res
 correctly.
 """
 
-import statsmodels.api as sm
 import numpy as np
 import pandas as pd
-from sklearn.datasets import fetch_openml
+import statsmodels.api as sm
 
-from turtles.stats.glms import PoissonReg
 from turtles.preprocess import one_hot_encode
-
+from turtles.stats.glms import PoissonReg
 
 # we'll increase the tolerance a bit because the models are fit using MLE
 tol = 1e-4
@@ -51,12 +49,7 @@ preds = model.predict(X)
 X = sm.add_constant(X)
 y = y.flatten()
 exposure = exposure.flatten()
-sm_model = sm.GLM(
-    y, 
-    X, 
-    exposure=exposure,
-    family=sm.families.Poisson()
-).fit()
+sm_model = sm.GLM(y, X, exposure=exposure, family=sm.families.Poisson()).fit()
 sm_preds = sm_model.predict(X)
 
 
@@ -78,38 +71,10 @@ def test_poissonreg():
     assert all([col in summary["Variable"].unique() for col in var_names])
     assert model.observations == sm_model.nobs
     assert model.degrees_of_freedom == sm_model.df_resid
-    np.isclose(
-        model.betas[0],
-        sm_model.params,
-        atol=tol
-    )
-    np.isclose(
-        model.p_values[0],
-        sm_model.pvalues,
-        atol=tol
-    )
-    np.isclose(
-        model.std_error_betas[0],
-        sm_model.bse,
-        atol=tol
-    )
-    np.isclose(
-        model.z_stat_betas[0],
-        sm_model.tvalues,
-        atol=tol
-    )
-    np.isclose(
-        preds,
-        sm_preds,
-        atol=tol
-    )
-    np.isclose(
-        model.deviance,
-        sm_model.deviance,
-        atol=tol
-    )
-    np.isclose(
-        model.dispersion,
-        sm_model.deviance / sm_model.df_resid,
-        atol=tol
-    )
+    np.isclose(model.betas[0], sm_model.params, atol=tol)
+    np.isclose(model.p_values[0], sm_model.pvalues, atol=tol)
+    np.isclose(model.std_error_betas[0], sm_model.bse, atol=tol)
+    np.isclose(model.z_stat_betas[0], sm_model.tvalues, atol=tol)
+    np.isclose(preds, sm_preds, atol=tol)
+    np.isclose(model.deviance, sm_model.deviance, atol=tol)
+    np.isclose(model.dispersion, sm_model.deviance / sm_model.df_resid, atol=tol)

--- a/turtles/stats/glms/tests/test_validation.py
+++ b/turtles/stats/glms/tests/test_validation.py
@@ -12,56 +12,50 @@ def test_failures():
 
     with pytest.raises(ValueError):
         GLM(
-            max_iter=1000, 
-            learning_rate=0.1, 
-            tolerance=0.01, 
-            method="test", 
-            beta_momentum=1.9
+            max_iter=1000,
+            learning_rate=0.1,
+            tolerance=0.01,
+            method="test",
+            beta_momentum=1.9,
         )
 
     with pytest.raises(ValueError):
         GLM(
-            max_iter=-5, 
-            learning_rate=0.1, 
-            tolerance=0.01, 
-            method="lbfgs", 
-            beta_momentum=1.0
+            max_iter=-5,
+            learning_rate=0.1,
+            tolerance=0.01,
+            method="lbfgs",
+            beta_momentum=1.0,
         )
 
     with pytest.raises(ValueError):
         GLM(
-            max_iter=1000, 
-            learning_rate=-0.1, 
-            tolerance=0.01, 
-            method="lbfgs", 
-            beta_momentum=0.6
+            max_iter=1000,
+            learning_rate=-0.1,
+            tolerance=0.01,
+            method="lbfgs",
+            beta_momentum=0.6,
         )
 
     with pytest.raises(TypeError):
         GLM(
-            max_iter=1000, 
-            learning_rate=0.1, 
-            tolerance=1, 
-            method="lbfgs", 
-            beta_momentum=0.6
+            max_iter=1000,
+            learning_rate=0.1,
+            tolerance=1,
+            method="lbfgs",
+            beta_momentum=0.6,
         )
 
     with pytest.raises(TypeError):
-        GLM(
-            max_iter=0, 
-            learning_rate=0, 
-            tolerance=0, 
-            method="lbfgs", 
-            beta_momentum=0
-        )
+        GLM(max_iter=0, learning_rate=0, tolerance=0, method="lbfgs", beta_momentum=0)
 
     with pytest.raises(TypeError):
         GLM(
-            max_iter=0.001, 
-            learning_rate=0.001, 
-            tolerance=0.999, 
-            method="grad", 
-            beta_momentum=0
+            max_iter=0.001,
+            learning_rate=0.001,
+            tolerance=0.999,
+            method="grad",
+            beta_momentum=0,
         )
 
 
@@ -69,17 +63,13 @@ def test_valid():
     """Test valid cases."""
 
     GLM(
-        max_iter=1000, 
-        learning_rate=0.1, 
-        tolerance=0.01, 
-        method="lbfgs", 
-        beta_momentum=0.6
+        max_iter=1000,
+        learning_rate=0.1,
+        tolerance=0.01,
+        method="lbfgs",
+        beta_momentum=0.6,
     )
 
     GLM(
-        max_iter=1, 
-        learning_rate=0.001, 
-        tolerance=0.999, 
-        method="grad", 
-        beta_momentum=0
+        max_iter=1, learning_rate=0.001, tolerance=0.999, method="grad", beta_momentum=0
     )

--- a/turtles/stats/tests/test_stats.py
+++ b/turtles/stats/tests/test_stats.py
@@ -2,17 +2,16 @@
 Unit tests for functions from the stats module.
 """
 
-import pytest
 import numpy as np
+import pytest
 
 from ...stats import (
+    calculate_errors,
     covariance_matrix,
     pca,
     pearson_corr,
     variance_inflation_factor,
-    calculate_errors
 )
-
 
 # generate random data for testing
 np.random.seed(11)
@@ -23,26 +22,76 @@ prec = 8
 
 true_cov = np.array(
     [
-        [ 0.08407138,  0.01703046, -0.00241016,  0.00151463,  0.00730384],
-        [ 0.01703046,  0.14481672,  0.01960091, -0.05035906,  0.02466841],
-        [-0.00241016,  0.01960091,  0.07601278,  0.04428605,  0.02239362],
-        [ 0.00151463, -0.05035906,  0.04428605,  0.08308211,  0.01975682],
-        [ 0.00730384,  0.02466841,  0.02239362,  0.01975682,  0.07193656]
+        [0.08407138, 0.01703046, -0.00241016, 0.00151463, 0.00730384],
+        [0.01703046, 0.14481672, 0.01960091, -0.05035906, 0.02466841],
+        [-0.00241016, 0.01960091, 0.07601278, 0.04428605, 0.02239362],
+        [0.00151463, -0.05035906, 0.04428605, 0.08308211, 0.01975682],
+        [0.00730384, 0.02466841, 0.02239362, 0.01975682, 0.07193656],
     ]
 )
 
 true_xc = np.array(
     [
-        [-0.27729601,  0.0278614 ,  0.27239877,  0.17476832,  0.30141389,      
-        -0.37361255, -0.05588922,  0.4915367 , -0.39387927, -0.16730203],
-       [-0.44870937, -0.4554038 , -0.35944854, -0.447701  ,  0.35009075,
-         0.24454132,  0.37979438,  0.51848872, -0.10356897,  0.32191651],
-       [-0.03045405, -0.00630097,  0.40023159, -0.37693531, -0.14904809,
-         0.10587082,  0.2241766 , -0.15561853, -0.42364978,  0.41172774],
-       [ 0.20806769,  0.42494041,  0.340288  , -0.20049893, -0.19806745,
-        -0.46119256,  0.08519781, -0.27699156, -0.19749854,  0.27575514],
-       [ 0.0035559 ,  0.43414739, -0.25156108, -0.25873539, -0.30498647,
-         0.06314958,  0.13573612,  0.37978805, -0.34626511,  0.14517101]
+        [
+            -0.27729601,
+            0.0278614,
+            0.27239877,
+            0.17476832,
+            0.30141389,
+            -0.37361255,
+            -0.05588922,
+            0.4915367,
+            -0.39387927,
+            -0.16730203,
+        ],
+        [
+            -0.44870937,
+            -0.4554038,
+            -0.35944854,
+            -0.447701,
+            0.35009075,
+            0.24454132,
+            0.37979438,
+            0.51848872,
+            -0.10356897,
+            0.32191651,
+        ],
+        [
+            -0.03045405,
+            -0.00630097,
+            0.40023159,
+            -0.37693531,
+            -0.14904809,
+            0.10587082,
+            0.2241766,
+            -0.15561853,
+            -0.42364978,
+            0.41172774,
+        ],
+        [
+            0.20806769,
+            0.42494041,
+            0.340288,
+            -0.20049893,
+            -0.19806745,
+            -0.46119256,
+            0.08519781,
+            -0.27699156,
+            -0.19749854,
+            0.27575514,
+        ],
+        [
+            0.0035559,
+            0.43414739,
+            -0.25156108,
+            -0.25873539,
+            -0.30498647,
+            0.06314958,
+            0.13573612,
+            0.37978805,
+            -0.34626511,
+            0.14517101,
+        ],
     ]
 )
 
@@ -52,12 +101,12 @@ true_pca = np.array(
         [0.51977265, -0.36291602],
         [0.45010573, -0.29370424],
         [0.31284923, 0.53863973],
-        [-0.39957495, 0.2567244 ],
+        [-0.39957495, 0.2567244],
         [-0.36262502, 0.15644358],
-        [-0.30559432, -0.3182399 ],
-        [-0.70545412, -0.0749282 ],
+        [-0.30559432, -0.3182399],
+        [-0.70545412, -0.0749282],
         [0.11838191, 0.61200282],
-        [-0.15601838, -0.5269897 ]
+        [-0.15601838, -0.5269897],
     ]
 )
 
@@ -66,24 +115,15 @@ def test_covariance_matrix():
     """Test covariance_matrix function."""
 
     C = covariance_matrix(X)
-    np.testing.assert_array_equal(
-        np.round(C, prec),
-        true_cov
-    )
+    np.testing.assert_array_equal(np.round(C, prec), true_cov)
 
 
 def test_covariance_matrix_xc():
     """Test covariance matrix function when X_c is requested."""
 
     C, X_c = covariance_matrix(X, return_xc=True)
-    np.testing.assert_array_equal(
-        np.round(C, prec),
-        true_cov
-    )
-    np.testing.assert_array_equal(
-        np.round(X_c, prec),
-        true_xc
-    )
+    np.testing.assert_array_equal(np.round(C, prec), true_cov)
+    np.testing.assert_array_equal(np.round(X_c, prec), true_xc)
 
 
 def test_covariance_invalid_case():
@@ -100,15 +140,9 @@ def test_pca():
     """Test PCA function."""
 
     result = pca(X, 2)
-    np.testing.assert_array_equal(
-        np.round(result, prec),
-        true_pca
-    )
+    np.testing.assert_array_equal(np.round(result, prec), true_pca)
     result = pca(X, 1)
-    np.testing.assert_array_equal(
-        np.round(result, prec),
-        np.array([true_pca[:,0]]).T
-    )
+    np.testing.assert_array_equal(np.round(result, prec), np.array([true_pca[:, 0]]).T)
 
 
 def test_pca_invalid_case():
@@ -164,13 +198,13 @@ def test_pearson_corr_invalid_case():
 
 def test_calculate_errors_valid():
     """Valid input."""
-    
+
     y_true = np.array([3, 5, 7, 9])
     y_pred = np.array([2.5, 5.5, 6.8, 9.2])
-    
+
     # calculate manually for validation:
     errors = y_true - y_pred
-    sse = np.sum(errors ** 2)
+    sse = np.sum(errors**2)
     mse = sse / len(y_true)
     rmse = np.sqrt(mse)
 
@@ -186,9 +220,9 @@ def test_calculate_errors_no_error():
 
     y_true = np.array([3, 5, 7, 9])
     y_pred = np.array([3, 5, 7, 9])
-    
+
     result = calculate_errors(y_true, y_pred)
-    
+
     assert np.isclose(result["Sum of Squared Errors"], 0.0)
     assert np.isclose(result["Mean Squared Error"], 0.0)
     assert np.isclose(result["Root Mean Squared Error"], 0.0)
@@ -199,16 +233,16 @@ def test_calculate_errors_custom_m():
 
     y_true = np.array([3, 5, 7, 9])
     y_pred = np.array([2.5, 5.5, 6.8, 9.2])
-    
+
     m = 3
-    
+
     result = calculate_errors(y_true, y_pred, m)
 
     errors = y_true - y_pred
-    sse = np.sum(errors ** 2)
+    sse = np.sum(errors**2)
     mse = sse / m
     rmse = np.sqrt(mse)
-    
+
     assert np.isclose(result["Sum of Squared Errors"], sse)
     assert np.isclose(result["Mean Squared Error"], mse)
     assert np.isclose(result["Root Mean Squared Error"], rmse)
@@ -219,7 +253,7 @@ def test_calculate_errors_shape_mismatch():
 
     y_true = np.array([1, 2, 3])
     y_pred = np.array([1, 2])
-    
+
     with pytest.raises(ValueError):
         calculate_errors(y_true, y_pred)
 
@@ -231,16 +265,12 @@ def test_variance_inflation_factor_basic():
     """Test basic functionality: column names, shape, and feasible results."""
 
     # perfect collinearity (should result in inf VIF values)
-    X = np.array([
-        [1, 2],
-        [2, 3],
-        [3, 4]
-    ])
+    X = np.array([[1, 2], [2, 3], [3, 4]])
 
     var_names = ["Test1", "Test2"]
 
     result = variance_inflation_factor(X, var_names)
-    
+
     assert all(col in result.columns for col in ["Coefficient", "R-squared", "VIF"])
     assert result.shape == (2, 3)
     assert np.all(np.isposinf(result["VIF"]))
@@ -250,14 +280,10 @@ def test_variance_inflation_factor_basic():
 def test_variance_inflation_factor_single_predictor():
     """Test edge case (single predictor)."""
 
-    X = np.array([
-        [1],
-        [2],
-        [3]
-    ])
-    
+    X = np.array([[1], [2], [3]])
+
     result = variance_inflation_factor(X)
-    
+
     assert result["VIF"].iloc[0] == 1.0
 
 
@@ -273,9 +299,5 @@ def test_variance_inflation_factor_invalid_shape():
     """Test invalid array shape."""
 
     with pytest.raises(ValueError):
-        X = np.array([
-            [1, 2, 3],
-            [4, 5, 6]
-        ])
+        X = np.array([[1, 2, 3], [4, 5, 6]])
         variance_inflation_factor(X)
-        

--- a/turtles/tests/test_utils.py
+++ b/turtles/tests/test_utils.py
@@ -2,15 +2,10 @@
 Unit tests for functions from the _utils module.
 """
 
-import pytest
 import numpy as np
+import pytest
 
-from .._utils import (
-    _add_intercept,
-    _validate_args,
-    _shape_check
-)
-
+from .._utils import _add_intercept, _shape_check, _validate_args
 
 # ----- _validate_args() -----
 
@@ -21,12 +16,7 @@ def test_valid_input():
     X = np.array([1, 2, 3])
     Y = [1.5, 2.5, 3.5]
 
-    _validate_args(
-        {
-            "X": (X, np.ndarray),
-            "Y": (Y, list)
-        }
-    )
+    _validate_args({"X": (X, np.ndarray), "Y": (Y, list)})
 
 
 def test_invalid_type_X():
@@ -36,15 +26,10 @@ def test_invalid_type_X():
     Y = [1.5, 2.5, 3.5]
 
     with pytest.raises(
-        TypeError, 
-        match="Parameter 'X' must be of type <class 'numpy.ndarray'>; received <class 'list'>"
+        TypeError,
+        match="Parameter 'X' must be of type <class 'numpy.ndarray'>; received <class 'list'>",
     ):
-        _validate_args(
-            {
-                "X": (X, np.ndarray),
-                "Y": (Y, (int, float))
-            }
-        )
+        _validate_args({"X": (X, np.ndarray), "Y": (Y, (int, float))})
 
 
 def test_invalid_type_Y():
@@ -54,29 +39,19 @@ def test_invalid_type_Y():
     Y = "invalid_string"
 
     with pytest.raises(
-        TypeError, 
-        match="Parameter 'Y' must be one of the types \\(<class 'int'>, <class 'float'>\\); received <class 'str'>"
+        TypeError,
+        match="Parameter 'Y' must be one of the types \\(<class 'int'>, <class 'float'>\\); received <class 'str'>",
     ):
-        _validate_args(
-            {
-                "X": (X, np.ndarray),
-                "Y": (Y, (int, float))
-            }
-        )
+        _validate_args({"X": (X, np.ndarray), "Y": (Y, (int, float))})
 
 
 def test_multiple_valid_types():
     """Test multiple valid types."""
 
     X = np.array([1, 2, 3])
-    Y = 4 
+    Y = 4
 
-    _validate_args(
-        {
-            "X": (X, np.ndarray),
-            "Y": (Y, (int, float))
-        }
-    )
+    _validate_args({"X": (X, np.ndarray), "Y": (Y, (int, float))})
 
 
 def test_multiple_invalid_types():
@@ -86,16 +61,11 @@ def test_multiple_invalid_types():
     Y = [1.5, 2.5, 3.5]
 
     with pytest.raises(
-        TypeError, 
-        match="Parameter 'X' must be of type <class 'numpy.ndarray'>; received <class 'float'>"
+        TypeError,
+        match="Parameter 'X' must be of type <class 'numpy.ndarray'>; received <class 'float'>",
     ):
-        
-        _validate_args(
-            {
-                "X": (X, np.ndarray),
-                "Y": (Y, (int, float))
-            }
-        )
+
+        _validate_args({"X": (X, np.ndarray), "Y": (Y, (int, float))})
 
 
 # ----- _add_intercept() -----
@@ -119,7 +89,7 @@ def test_add_intercept_empty():
     X = np.array([]).reshape(0, 0)
 
     expected_output = np.array([]).reshape(0, 1)
-    
+
     result = _add_intercept(X)
     np.testing.assert_array_equal(result, expected_output)
 


### PR DESCRIPTION
- Catch singular matrices when computing Hessian; notify user to try decreasing the `learning_rate` hyperparameter.
- Run all files through new pre-commit hooks.
- Update README with better usage documentation
- Bump patch version